### PR TITLE
Race condition fix

### DIFF
--- a/ValidationLibrary.AzureFunctions.Tests/RepositoryValidatorEndpointTests.cs
+++ b/ValidationLibrary.AzureFunctions.Tests/RepositoryValidatorEndpointTests.cs
@@ -92,8 +92,9 @@ namespace ValidationLibrary.AzureFunctions.Tests
         [Test]
         public async Task RunActivity_ValidatesTrigger()
         {
-            const string InstanceId = "7E467BDB-213F-407A-B86A-1954053D3C27";
+            const string InstanceId = "by-pinja_repository-validator-testing";
             _mockDurableClient.StartNewAsync(Arg.Any<string>(), Arg.Any<object>()).Returns(Task.FromResult(InstanceId));
+            _mockDurableClient.GetStatusAsync(Arg.Any<string>()).Returns(Task.FromResult<DurableOrchestrationStatus>(null));
 
             _mockDurableClient.CreateCheckStatusResponse(Arg.Any<HttpRequestMessage>(), InstanceId).Returns(new HttpResponseMessage
             {
@@ -121,14 +122,14 @@ namespace ValidationLibrary.AzureFunctions.Tests
             var result = await RepositoryValidatorEndpoint.RepositoryValidatorTrigger(request, _mockDurableClient, Substitute.For<ILogger>());
 
             Assert.AreEqual(result.StatusCode, HttpStatusCode.OK);
-            await _mockDurableClient.Received().StartNewAsync(Arg.Any<string>(), Arg.Any<object>());
+            await _mockDurableClient.Received().StartNewAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>());
             _mockDurableClient.Received().CreateCheckStatusResponse(Arg.Any<HttpRequestMessage>(), InstanceId);
         }
 
         [Test]
         public async Task RunActivity_InnvalidJsonThrowsError()
         {
-            const string InstanceId = "7E467BDB-213F-407A-B86A-1954053D3C27";
+            const string InstanceId = "test_repository-validator-testing";
             _mockDurableClient.StartNewAsync(Arg.Any<string>(), Arg.Any<object>()).Returns(Task.FromResult(InstanceId));
 
             _mockDurableClient.CreateCheckStatusResponse(Arg.Any<HttpRequestMessage>(), InstanceId).Returns(new HttpResponseMessage

--- a/ValidationLibrary.AzureFunctions.Tests/RepositoryValidatorEndpointTests.cs
+++ b/ValidationLibrary.AzureFunctions.Tests/RepositoryValidatorEndpointTests.cs
@@ -98,24 +98,54 @@ namespace ValidationLibrary.AzureFunctions.Tests
         [Test]
         public async Task RunActivity_InvalidJsonThrowsError()
         {
-            var dynamic = new
-            {
-                repository = new
+            var invalidObjects = new dynamic[]{
+                new
                 {
-                    name = "repository-validator-testing",
-                    owner = "test"
+                    repository = new
+                    {
+                        name = "repository-validator-testing",
+                        owner = "test"
+                    }
+                },
+                new
+                {
+                    repository = new
+                    {
+                        name = "repository-validator-testing"
+                    }
+                },
+                new
+                {
+                    repository = new
+                    {
+                        name = "repository-validator-testing",
+                        owner = (object)null
+                    }
+                },
+                new
+                {
+                    repository = new
+                    {
+                        owner = new
+                        {
+                            login = "test"
+                        }
+                    }
                 }
             };
 
-            var request = new HttpRequestMessage()
+            foreach (var dynamic in invalidObjects)
             {
-                Content = new StringContent(JsonConvert.SerializeObject(dynamic), System.Text.Encoding.UTF8, "application/json"),
-            };
+                var request = new HttpRequestMessage()
+                {
+                    Content = new StringContent(JsonConvert.SerializeObject(dynamic), System.Text.Encoding.UTF8, "application/json"),
+                };
 
-            var result = await RepositoryValidatorEndpoint.RepositoryValidatorTrigger(request, _mockDurableClient, Substitute.For<ILogger>());
-            Assert.AreEqual(HttpStatusCode.BadRequest, result.StatusCode);
-            await _mockDurableClient.DidNotReceive().StartNewAsync(Arg.Any<string>(), Arg.Any<object>());
-            _mockDurableClient.DidNotReceive().CreateCheckStatusResponse(Arg.Any<HttpRequestMessage>(), Arg.Any<string>());
+                var result = await RepositoryValidatorEndpoint.RepositoryValidatorTrigger(request, _mockDurableClient, Substitute.For<ILogger>());
+                Assert.AreEqual(HttpStatusCode.BadRequest, result.StatusCode);
+                await _mockDurableClient.DidNotReceive().StartNewAsync(Arg.Any<string>(), Arg.Any<object>());
+                _mockDurableClient.DidNotReceive().CreateCheckStatusResponse(Arg.Any<HttpRequestMessage>(), Arg.Any<string>());
+            }
         }
 
         [Test]

--- a/ValidationLibrary.AzureFunctions/GitHubDto/Owner.cs
+++ b/ValidationLibrary.AzureFunctions/GitHubDto/Owner.cs
@@ -4,7 +4,6 @@ namespace ValidationLibrary.AzureFunctions.GitHubDto
 {
     public class Owner
     {
-        [JsonProperty(PropertyName = "login", Required = Required.Always)]
         public string Login { get; set; }
     }
 }

--- a/ValidationLibrary.AzureFunctions/GitHubDto/Owner.cs
+++ b/ValidationLibrary.AzureFunctions/GitHubDto/Owner.cs
@@ -4,7 +4,7 @@ namespace ValidationLibrary.AzureFunctions.GitHubDto
 {
     public class Owner
     {
-        [JsonProperty(PropertyName = "login")]
+        [JsonProperty(PropertyName = "login", Required = Required.Always)]
         public string Login { get; set; }
     }
 }

--- a/ValidationLibrary.AzureFunctions/GitHubDto/Owner.cs
+++ b/ValidationLibrary.AzureFunctions/GitHubDto/Owner.cs
@@ -1,5 +1,3 @@
-using Newtonsoft.Json;
-
 namespace ValidationLibrary.AzureFunctions.GitHubDto
 {
     public class Owner

--- a/ValidationLibrary.AzureFunctions/GitHubDto/PushData.cs
+++ b/ValidationLibrary.AzureFunctions/GitHubDto/PushData.cs
@@ -4,7 +4,7 @@ namespace ValidationLibrary.AzureFunctions.GitHubDto
 {
     public class PushData
     {
-        [JsonProperty(PropertyName = "repository")]
+        [JsonProperty(PropertyName = "repository", Required = Required.Always)]
         public Repository Repository { get; set; }
     }
 }

--- a/ValidationLibrary.AzureFunctions/GitHubDto/PushData.cs
+++ b/ValidationLibrary.AzureFunctions/GitHubDto/PushData.cs
@@ -4,7 +4,6 @@ namespace ValidationLibrary.AzureFunctions.GitHubDto
 {
     public class PushData
     {
-        [JsonProperty(PropertyName = "repository", Required = Required.Always)]
         public Repository Repository { get; set; }
     }
 }

--- a/ValidationLibrary.AzureFunctions/GitHubDto/PushData.cs
+++ b/ValidationLibrary.AzureFunctions/GitHubDto/PushData.cs
@@ -1,5 +1,3 @@
-using Newtonsoft.Json;
-
 namespace ValidationLibrary.AzureFunctions.GitHubDto
 {
     public class PushData

--- a/ValidationLibrary.AzureFunctions/GitHubDto/Repository.cs
+++ b/ValidationLibrary.AzureFunctions/GitHubDto/Repository.cs
@@ -1,5 +1,3 @@
-using Newtonsoft.Json;
-
 namespace ValidationLibrary.AzureFunctions.GitHubDto
 {
     public class Repository

--- a/ValidationLibrary.AzureFunctions/GitHubDto/Repository.cs
+++ b/ValidationLibrary.AzureFunctions/GitHubDto/Repository.cs
@@ -4,10 +4,7 @@ namespace ValidationLibrary.AzureFunctions.GitHubDto
 {
     public class Repository
     {
-        [JsonProperty(PropertyName = "name", Required = Required.Always)]
         public string Name { get; set; }
-
-        [JsonProperty(PropertyName = "owner", Required = Required.Always)]
         public Owner Owner { get; set; }
     }
 }

--- a/ValidationLibrary.AzureFunctions/GitHubDto/Repository.cs
+++ b/ValidationLibrary.AzureFunctions/GitHubDto/Repository.cs
@@ -4,10 +4,10 @@ namespace ValidationLibrary.AzureFunctions.GitHubDto
 {
     public class Repository
     {
-        [JsonProperty(PropertyName = "name")]
+        [JsonProperty(PropertyName = "name", Required = Required.Always)]
         public string Name { get; set; }
 
-        [JsonProperty(PropertyName = "owner")]
+        [JsonProperty(PropertyName = "owner", Required = Required.Always)]
         public Owner Owner { get; set; }
     }
 }

--- a/ValidationLibrary.AzureFunctions/RepositoryValidatorEndpoint.cs
+++ b/ValidationLibrary.AzureFunctions/RepositoryValidatorEndpoint.cs
@@ -128,16 +128,6 @@ namespace ValidationLibrary.AzureFunctions
                 throw new ArgumentNullException(nameof(content), "Content was null. Unable to retrieve parameters.");
             }
 
-            if (content.Repository is null)
-            {
-                throw new ArgumentException("No repository defined in content. Unable to validate repository.");
-            }
-
-            if (content.Repository.Owner is null)
-            {
-                throw new ArgumentException("No repository owner defined. Unable to validate repository.");
-            }
-
             if (string.IsNullOrEmpty(content.Repository.Name))
             {
                 throw new ArgumentException("No repository name defined. Unable to validate repository.");

--- a/ValidationLibrary.AzureFunctions/RepositoryValidatorEndpoint.cs
+++ b/ValidationLibrary.AzureFunctions/RepositoryValidatorEndpoint.cs
@@ -39,7 +39,8 @@ namespace ValidationLibrary.AzureFunctions
 
             try
             {
-                var content = await req.Content.ReadAsAsync<PushData>().ConfigureAwait(false);
+                var stringContent = await req.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var content = JsonConvert.DeserializeObject<PushData>(stringContent);
                 ValidateInput(content);
                 logger.LogDebug("Request json valid.");
                 var instanceId = CreateInstanceId(content);
@@ -64,6 +65,7 @@ namespace ValidationLibrary.AzureFunctions
             }
             catch (Exception exception) when (exception is ArgumentException || exception is JsonSerializationException)
             {
+                Console.WriteLine("Vittu {0}", exception.Message);
                 logger.LogError(exception, "Invalid request received, can't perform validation.");
                 return new HttpResponseMessage(HttpStatusCode.BadRequest);
             }

--- a/ValidationLibrary.AzureFunctions/RepositoryValidatorEndpoint.cs
+++ b/ValidationLibrary.AzureFunctions/RepositoryValidatorEndpoint.cs
@@ -39,8 +39,7 @@ namespace ValidationLibrary.AzureFunctions
 
             try
             {
-                var stringContent = await req.Content.ReadAsStringAsync().ConfigureAwait(false);
-                var content = JsonConvert.DeserializeObject<PushData>(stringContent);
+                var content = await req.Content.ReadAsAsync<PushData>().ConfigureAwait(false);
                 ValidateInput(content);
                 logger.LogDebug("Request json valid.");
                 var instanceId = CreateInstanceId(content);
@@ -65,7 +64,6 @@ namespace ValidationLibrary.AzureFunctions
             }
             catch (Exception exception) when (exception is ArgumentException || exception is JsonSerializationException)
             {
-                Console.WriteLine("Vittu {0}", exception.Message);
                 logger.LogError(exception, "Invalid request received, can't perform validation.");
                 return new HttpResponseMessage(HttpStatusCode.BadRequest);
             }
@@ -128,6 +126,16 @@ namespace ValidationLibrary.AzureFunctions
             if (content is null)
             {
                 throw new ArgumentNullException(nameof(content), "Content was null. Unable to retrieve parameters.");
+            }
+
+            if (content.Repository is null)
+            {
+                throw new ArgumentException("No repository defined in content. Unable to validate repository.");
+            }
+
+            if (content.Repository.Owner is null)
+            {
+                throw new ArgumentException("No repository owner defined. Unable to validate repository.");
             }
 
             if (string.IsNullOrEmpty(content.Repository.Name))

--- a/ValidationLibrary.AzureFunctions/RepositoryValidatorEndpoint.cs
+++ b/ValidationLibrary.AzureFunctions/RepositoryValidatorEndpoint.cs
@@ -54,11 +54,11 @@ namespace ValidationLibrary.AzureFunctions
                 else if (IsFinished(existingInstance.RuntimeStatus))
                 {
                     await starter.StartNewAsync(nameof(RunOrchestrator), instanceId, content).ConfigureAwait(false);
-                    logger.LogInformation("Orchestration with ID = '{instanceId}' already running, not creating a new one.", instanceId);
+                    logger.LogInformation("Orchestration with ID = '{instanceId}' status was {status}, starting a new one.", instanceId, existingInstance.RuntimeStatus);
                 }
                 else
                 {
-                    logger.LogInformation("Orchestration with ID = '{instanceId}' status was {status}, starting a new one.", instanceId, existingInstance.RuntimeStatus);
+                    logger.LogInformation("Orchestration with ID = '{instanceId}' status was {status}, already running, not creating a new one.", instanceId, existingInstance.RuntimeStatus);
                 }
                 return starter.CreateCheckStatusResponse(req, instanceId);
             }

--- a/ValidationLibrary.AzureFunctions/RepositoryValidatorEndpoint.cs
+++ b/ValidationLibrary.AzureFunctions/RepositoryValidatorEndpoint.cs
@@ -40,7 +40,6 @@ namespace ValidationLibrary.AzureFunctions
             try
             {
                 var content = await req.Content.ReadAsAsync<PushData>().ConfigureAwait(false);
-                // Validation is done twice for developer convenience.
                 ValidateInput(content);
                 logger.LogDebug("Request json valid.");
                 var instanceId = CreateInstanceId(content);
@@ -84,9 +83,10 @@ namespace ValidationLibrary.AzureFunctions
         {
             try
             {
+                if (content is null) throw new ArgumentNullException(nameof(content), "No content to execute the activity.");
+
                 logger.LogDebug("Executing validation activity.");
                 ValidateInput(content);
-                if (content is null) throw new ArgumentNullException(nameof(content), "No content to execute the activity.");
 
                 logger.LogInformation("Doing validation. Repository {owner}/{repositoryName}", content.Repository?.Owner?.Login, content.Repository?.Name);
                 await _validationClient.Init().ConfigureAwait(false);
@@ -104,7 +104,6 @@ namespace ValidationLibrary.AzureFunctions
             catch (ArgumentException exception)
             {
                 logger.LogError(exception, "Invalid request received");
-
                 return new BadRequestResult();
             }
         }

--- a/ValidationLibrary.AzureFunctions/RepositoryValidatorEndpoint.cs
+++ b/ValidationLibrary.AzureFunctions/RepositoryValidatorEndpoint.cs
@@ -43,7 +43,7 @@ namespace ValidationLibrary.AzureFunctions
                 // Validation is done twice for developer convenience.
                 ValidateInput(content);
                 logger.LogDebug("Request json valid.");
-                var instanceId = $"{content.Repository?.Owner?.Login}_{content.Repository?.Name}";
+                var instanceId = CreateInstanceId(content);
 
                 var existingInstance = await starter.GetStatusAsync(instanceId).ConfigureAwait(false);
                 if (existingInstance == null)
@@ -115,6 +115,11 @@ namespace ValidationLibrary.AzureFunctions
                 || status == OrchestrationRuntimeStatus.Failed
                 || status == OrchestrationRuntimeStatus.Terminated
                 || status == OrchestrationRuntimeStatus.Completed;
+        }
+
+        private static string CreateInstanceId(PushData content)
+        {
+            return $"{content.Repository?.Owner?.Login}_{content.Repository?.Name}";
         }
 
         private static void ValidateInput(PushData content)

--- a/ValidationLibrary.GitHub/GitHubReporter.cs
+++ b/ValidationLibrary.GitHub/GitHubReporter.cs
@@ -84,17 +84,17 @@ namespace ValidationLibrary.GitHub
 
         private async Task CloseIfNeeded(ValidationReport report, ValidationResult result, IEnumerable<Issue> existingIssues)
         {
-            _logger.LogTrace("Closing issues if needed for rule {0}", result.RuleName);
+            _logger.LogTrace("Closing issues if needed for rule {rule}", result.RuleName);
             foreach (var existingIssue in existingIssues)
             {
-                _logger.LogTrace("Checking issue: #{0}, state: {1}", existingIssue.Number, existingIssue.State);
+                _logger.LogTrace("Checking issue: #{ruleName}, state: {issueState}", existingIssue.Number, existingIssue.State);
                 if (existingIssue.State == ItemState.Open)
                 {
-                    _logger.LogTrace("Found open issue #{0}", existingIssue.Number);
+                    _logger.LogTrace("Found open issue #{issueId}", existingIssue.Number);
                     await _client.Issue.Comment.Create(report.Owner, report.RepositoryName, existingIssue.Number, $"{_config.Prefix}: Issue fixed. Closing issue.").ConfigureAwait(false);
                     var update = new IssueUpdate() { State = ItemState.Closed };
                     await _client.Issue.Update(report.Owner, report.RepositoryName, existingIssue.Number, update).ConfigureAwait(false);
-                    _logger.LogInformation("Closed issue #{0} for {1}/{2}", existingIssue.Number, report.Owner, report.RepositoryName);
+                    _logger.LogInformation("Closed issue #{issueId} for {owner}/{repositoryName}", existingIssue.Number, report.Owner, report.RepositoryName);
                 }
             }
         }
@@ -103,12 +103,12 @@ namespace ValidationLibrary.GitHub
         {
             if (!existingIssues.Any())
             {
-                _logger.LogInformation("No issues found, creating new issue for {0}/{1}.", report.Owner, report.RepositoryName);
+                _logger.LogInformation("No issues found, creating new issue for {owner}/{repositoryName}.", report.Owner, report.RepositoryName);
                 await _client.Issue.Create(report.Owner, report.RepositoryName, CreateIssue(result)).ConfigureAwait(false);
             }
             else
             {
-                _logger.LogTrace("Found {0} existing issues.", existingIssues.Count());
+                _logger.LogTrace("Found {issueCount} existing issues.", existingIssues.Count());
                 var openIssue = existingIssues.FirstOrDefault(issue => issue.State == ItemState.Open);
                 if (openIssue != null)
                 {
@@ -121,7 +121,7 @@ namespace ValidationLibrary.GitHub
 
                 var update = new IssueUpdate() { State = ItemState.Open };
                 await _client.Issue.Update(report.Owner, report.RepositoryName, closedIssue.Number, update).ConfigureAwait(false);
-                _logger.LogInformation("Reopened issue #{0} for {1}/{2}", closedIssue.Number, report.Owner, report.RepositoryName);
+                _logger.LogInformation("Reopened issue #{issueId} for {owner}/{repositoryName}", closedIssue.Number, report.Owner, report.RepositoryName);
             }
         }
 


### PR DESCRIPTION
If validation webhook is called multiple times for same repository at the same time, it may create multiple issues for same validation failure if there are no existing issues. This fix should make it so that if there is already validation going we don't start a new validation instance.

#311 