### PR TITLE
Production release

### DIFF
--- a/AcceptanceTests/AcceptanceTests.csproj
+++ b/AcceptanceTests/AcceptanceTests.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.4" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />

--- a/AcceptanceTests/AcceptanceTests.csproj
+++ b/AcceptanceTests/AcceptanceTests.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.6" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />

--- a/AcceptanceTests/AcceptanceTests.csproj
+++ b/AcceptanceTests/AcceptanceTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.2.1">
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/AcceptanceTests/AcceptanceTests.csproj
+++ b/AcceptanceTests/AcceptanceTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="RestSharp" Version="106.11.3" />
+    <PackageReference Include="RestSharp" Version="106.11.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AcceptanceTests/AcceptanceTests.csproj
+++ b/AcceptanceTests/AcceptanceTests.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.5" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="RestSharp" Version="106.11.4" />
   </ItemGroup>

--- a/AcceptanceTests/AcceptanceTests.csproj
+++ b/AcceptanceTests/AcceptanceTests.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.5" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />

--- a/AcceptanceTests/AcceptanceTests.csproj
+++ b/AcceptanceTests/AcceptanceTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="RestSharp" Version="106.10.1" />
+    <PackageReference Include="RestSharp" Version="106.11.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AcceptanceTests/AcceptanceTests.csproj
+++ b/AcceptanceTests/AcceptanceTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="RestSharp" Version="106.11.2" />
+    <PackageReference Include="RestSharp" Version="106.11.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Runner.Tests/Runner.Tests.csproj
+++ b/Runner.Tests/Runner.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.2.1">
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Runner.Tests/Runner.Tests.csproj
+++ b/Runner.Tests/Runner.Tests.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
   </ItemGroup>
 

--- a/Runner/Runner.csproj
+++ b/Runner/Runner.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Runner/Runner.csproj
+++ b/Runner/Runner.csproj
@@ -7,12 +7,12 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Runner/Runner.csproj
+++ b/Runner/Runner.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />

--- a/Runner/Runner.csproj
+++ b/Runner/Runner.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.3" />

--- a/Runner/Runner.csproj
+++ b/Runner/Runner.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
   </ItemGroup>
 

--- a/Runner/Runner.csproj
+++ b/Runner/Runner.csproj
@@ -7,12 +7,12 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Runner/Runner.csproj
+++ b/Runner/Runner.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />

--- a/Runner/Runner.csproj
+++ b/Runner/Runner.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
   </ItemGroup>

--- a/ValidationLibrary.AzureFunctions.Tests/ValidationLibrary.AzureFunctions.Tests.csproj
+++ b/ValidationLibrary.AzureFunctions.Tests/ValidationLibrary.AzureFunctions.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.2.1">
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/ValidationLibrary.AzureFunctions.Tests/ValidationLibrary.AzureFunctions.Tests.csproj
+++ b/ValidationLibrary.AzureFunctions.Tests/ValidationLibrary.AzureFunctions.Tests.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="nsubstitute" Version="4.2.1" />
+    <PackageReference Include="nsubstitute" Version="4.2.2" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />

--- a/ValidationLibrary.AzureFunctions.Tests/ValidationLibrary.AzureFunctions.Tests.csproj
+++ b/ValidationLibrary.AzureFunctions.Tests/ValidationLibrary.AzureFunctions.Tests.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="nsubstitute" Version="4.2.2" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
   </ItemGroup>
 

--- a/ValidationLibrary.AzureFunctions/ValidationLibrary.AzureFunctions.csproj
+++ b/ValidationLibrary.AzureFunctions/ValidationLibrary.AzureFunctions.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.14.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.2.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.2.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/ValidationLibrary.AzureFunctions/ValidationLibrary.AzureFunctions.csproj
+++ b/ValidationLibrary.AzureFunctions/ValidationLibrary.AzureFunctions.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/ValidationLibrary.AzureFunctions/ValidationLibrary.AzureFunctions.csproj
+++ b/ValidationLibrary.AzureFunctions/ValidationLibrary.AzureFunctions.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.6" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/ValidationLibrary.GitHub.Tests/GitHubReporterTests.cs
+++ b/ValidationLibrary.GitHub.Tests/GitHubReporterTests.cs
@@ -184,7 +184,7 @@ namespace ValidationLibrary.GitHub.Tests
 
         private Repository CreateRepository(string owner, string name, bool hasIssues, bool archived)
         {
-            return new Repository(null, null, null, null, null, null, null, 0, null, null, name, $"{owner}/{name}", false, null, null, null, false, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, hasIssues, false, false, false, 0, 0, null, null, null, archived);
+            return new Repository(null, null, null, null, null, null, null, 0, null, null, name, $"{owner}/{name}", false, null, null, null, false, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, hasIssues, false, false, false, 0, 0, null, null, null, archived, 0);
         }
     }
 }

--- a/ValidationLibrary.GitHub.Tests/ValidationLibrary.GitHub.Tests.csproj
+++ b/ValidationLibrary.GitHub.Tests/ValidationLibrary.GitHub.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.2.1">
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/ValidationLibrary.GitHub.Tests/ValidationLibrary.GitHub.Tests.csproj
+++ b/ValidationLibrary.GitHub.Tests/ValidationLibrary.GitHub.Tests.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="nsubstitute" Version="4.2.1" />
+    <PackageReference Include="nsubstitute" Version="4.2.2" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />

--- a/ValidationLibrary.GitHub.Tests/ValidationLibrary.GitHub.Tests.csproj
+++ b/ValidationLibrary.GitHub.Tests/ValidationLibrary.GitHub.Tests.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="nsubstitute" Version="4.2.2" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
   </ItemGroup>
 

--- a/ValidationLibrary.GitHub/ValidationLibrary.GitHub.csproj
+++ b/ValidationLibrary.GitHub/ValidationLibrary.GitHub.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Octokit" Version="0.47.0" />
+    <PackageReference Include="Octokit" Version="0.48.0" />
   </ItemGroup>
 
 </Project>

--- a/ValidationLibrary.MarkdownGenerator.Tests/ValidationLibrary.MarkdownGenerator.Tests.csproj
+++ b/ValidationLibrary.MarkdownGenerator.Tests/ValidationLibrary.MarkdownGenerator.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.2.1">
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/ValidationLibrary.MarkdownGenerator.Tests/ValidationLibrary.MarkdownGenerator.Tests.csproj
+++ b/ValidationLibrary.MarkdownGenerator.Tests/ValidationLibrary.MarkdownGenerator.Tests.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
   </ItemGroup>
 

--- a/ValidationLibrary.Rules.Tests/BaseRuleTests.cs
+++ b/ValidationLibrary.Rules.Tests/BaseRuleTests.cs
@@ -61,7 +61,7 @@ namespace ValidationLibrary.Tests.Rules
 
         private Repository CreateRepository(string name)
         {
-            return new Repository(null, null, null, null, null, null, null, 0, null, Owner, name, null, false, null, null, null, false, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, false, false, false, false, 0, 0, null, null, null, false);
+            return new Repository(null, null, null, null, null, null, null, 0, null, Owner, name, null, false, null, null, null, false, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, false, false, false, false, 0, 0, null, null, null, false, 0);
         }
     }
 }

--- a/ValidationLibrary.Rules.Tests/HasCodeownersRuleTests.cs
+++ b/ValidationLibrary.Rules.Tests/HasCodeownersRuleTests.cs
@@ -105,7 +105,7 @@ namespace ValidationLibrary.Tests.Rules
 
         private Repository CreateRepository(string name)
         {
-            return new Repository(null, null, null, null, null, null, null, 0, null, Owner, name, null, false, null, null, null, false, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, false, false, false, false, 0, 0, null, null, null, false);
+            return new Repository(null, null, null, null, null, null, null, 0, null, Owner, name, null, false, null, null, null, false, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, false, false, false, false, 0, 0, null, null, null, false, 0);
         }
     }
 }

--- a/ValidationLibrary.Rules.Tests/HasLicenseRuleTests.cs
+++ b/ValidationLibrary.Rules.Tests/HasLicenseRuleTests.cs
@@ -46,7 +46,7 @@ namespace ValidationLibrary.Tests.Rules
 
         private Repository CreateRepository(string name, bool isPrivate, LicenseMetadata license)
         {
-            return new Repository(null, null, null, null, null, null, null, 0, null, null, name, null, false, null, null, null, isPrivate, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, license, false, false, false, false, 0, 0, null, null, null, false);
+            return new Repository(null, null, null, null, null, null, null, 0, null, null, name, null, false, null, null, null, isPrivate, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, license, false, false, false, false, 0, 0, null, null, null, false, 0);
         }
     }
 }

--- a/ValidationLibrary.Rules.Tests/HasNewestPtcsJenkinsLibRuleTests.cs
+++ b/ValidationLibrary.Rules.Tests/HasNewestPtcsJenkinsLibRuleTests.cs
@@ -115,7 +115,7 @@ namespace ValidationLibrary.Tests.Rules
 
         private Repository CreateRepository(string name)
         {
-            return new Repository(null, null, null, null, null, null, null, 0, null, Owner, name, null, false, null, null, null, false, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, false, false, false, false, 0, 0, null, null, null, false);
+            return new Repository(null, null, null, null, null, null, null, 0, null, Owner, name, null, false, null, null, null, false, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, false, false, false, false, 0, 0, null, null, null, false, 0);
         }
     }
 }

--- a/ValidationLibrary.Rules.Tests/HasNotManyStaleBranchesRuleTests.cs
+++ b/ValidationLibrary.Rules.Tests/HasNotManyStaleBranchesRuleTests.cs
@@ -50,7 +50,7 @@ namespace ValidationLibrary.Tests.Rules
                 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow,
                 null, null, null, null, false, false,
                 false, false, 0, 0, null, null,
-                null, false);
+                null, false, 0);
         }
 
         private IReadOnlyList<Branch> CreateBranchList(int count, Repository repository)

--- a/ValidationLibrary.Rules.Tests/HasReadmeRuleTests.cs
+++ b/ValidationLibrary.Rules.Tests/HasReadmeRuleTests.cs
@@ -23,7 +23,7 @@ namespace ValidationLibrary.Tests.Rules
         }
 
         [Test]
-        public async Task IsValid_ReturnsOkWhenReadmeExists([Values("ReAdMe.md", "rEaDmE.txt", "README", "readme", "ReAdMe.doc")]string readMeName)
+        public async Task IsValid_ReturnsOkWhenReadmeExists([Values("ReAdMe.md", "rEaDmE.txt", "README", "readme", "ReAdMe.doc")] string readMeName)
         {
             var readme = CreateContent(readMeName, "random content");
             IReadOnlyList<RepositoryContent> contents = new[] { readme };
@@ -36,7 +36,7 @@ namespace ValidationLibrary.Tests.Rules
         }
 
         [Test]
-        public async Task IsValid_ReturnsFalseWhenReadmeDoesNotExist([Values("aREADME.md", "rEaDmE.txta", "README.", "readm", "ReAdMea.doc", "")]string readMeName)
+        public async Task IsValid_ReturnsFalseWhenReadmeDoesNotExist([Values("aREADME.md", "rEaDmE.txta", "README.", "readm", "ReAdMea.doc", "")] string readMeName)
         {
             var contents = new List<RepositoryContent>();
             if (!string.IsNullOrEmpty(readMeName))
@@ -77,7 +77,7 @@ namespace ValidationLibrary.Tests.Rules
 
         private Repository CreateRepository(string name)
         {
-            return new Repository(null, null, null, null, null, null, null, 0, null, Owner, name, null, false, null, null, null, false, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, false, false, false, false, 0, 0, null, null, null, false);
+            return new Repository(null, null, null, null, null, null, null, 0, null, Owner, name, null, false, null, null, null, false, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, false, false, false, false, 0, 0, null, null, null, false, 0);
         }
     }
 }

--- a/ValidationLibrary.Rules.Tests/ValidationLibrary.Rules.Tests.csproj
+++ b/ValidationLibrary.Rules.Tests/ValidationLibrary.Rules.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.2.1">
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/ValidationLibrary.Rules.Tests/ValidationLibrary.Rules.Tests.csproj
+++ b/ValidationLibrary.Rules.Tests/ValidationLibrary.Rules.Tests.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="nsubstitute" Version="4.2.1" />
+    <PackageReference Include="nsubstitute" Version="4.2.2" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />

--- a/ValidationLibrary.Rules.Tests/ValidationLibrary.Rules.Tests.csproj
+++ b/ValidationLibrary.Rules.Tests/ValidationLibrary.Rules.Tests.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="nsubstitute" Version="4.2.2" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
   </ItemGroup>
 

--- a/ValidationLibrary.Rules/ValidationLibrary.Rules.csproj
+++ b/ValidationLibrary.Rules/ValidationLibrary.Rules.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
-    <PackageReference Include="Octokit" Version="0.47.0" />
+    <PackageReference Include="Octokit" Version="0.48.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ValidationLibrary.Rules/ValidationLibrary.Rules.csproj
+++ b/ValidationLibrary.Rules/ValidationLibrary.Rules.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
     <PackageReference Include="Octokit" Version="0.48.0" />
   </ItemGroup>
 

--- a/ValidationLibrary.Rules/ValidationLibrary.Rules.csproj
+++ b/ValidationLibrary.Rules/ValidationLibrary.Rules.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
     <PackageReference Include="Octokit" Version="0.47.0" />
   </ItemGroup>
 

--- a/ValidationLibrary.Rules/ValidationLibrary.Rules.csproj
+++ b/ValidationLibrary.Rules/ValidationLibrary.Rules.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
     <PackageReference Include="Octokit" Version="0.48.0" />
   </ItemGroup>
 

--- a/ValidationLibrary.Tests/Utils/GitUtilsTests.cs
+++ b/ValidationLibrary.Tests/Utils/GitUtilsTests.cs
@@ -89,7 +89,7 @@ namespace ValidationLibrary.Tests.Utils
 
         private Repository CreateRepository(string name)
         {
-            return new Repository(null, null, null, null, null, null, null, 0, null, CreateUser(), name, null, false, null, null, null, false, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, false, false, false, false, 0, 0, null, null, null, false);
+            return new Repository(null, null, null, null, null, null, null, 0, null, CreateUser(), name, null, false, null, null, null, false, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, false, false, false, false, 0, 0, null, null, null, false, 0);
         }
 
         private User CreateUser()

--- a/ValidationLibrary.Tests/ValidationLibrary.Tests.csproj
+++ b/ValidationLibrary.Tests/ValidationLibrary.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.2.1">
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/ValidationLibrary.Tests/ValidationLibrary.Tests.csproj
+++ b/ValidationLibrary.Tests/ValidationLibrary.Tests.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="nsubstitute" Version="4.2.1" />
+    <PackageReference Include="nsubstitute" Version="4.2.2" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />

--- a/ValidationLibrary.Tests/ValidationLibrary.Tests.csproj
+++ b/ValidationLibrary.Tests/ValidationLibrary.Tests.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="nsubstitute" Version="4.2.2" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
   </ItemGroup>
 

--- a/ValidationLibrary/ValidationLibrary.csproj
+++ b/ValidationLibrary/ValidationLibrary.csproj
@@ -16,7 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Octokit" Version="0.47.0" />
+    <PackageReference Include="Octokit" Version="0.48.0" />
   </ItemGroup>
 
 </Project>

--- a/ValidationLibrary/ValidationLibrary.csproj
+++ b/ValidationLibrary/ValidationLibrary.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Octokit" Version="0.48.0" />
   </ItemGroup>

--- a/ValidationLibrary/ValidationLibrary.csproj
+++ b/ValidationLibrary/ValidationLibrary.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Octokit" Version="0.47.0" />
   </ItemGroup>

--- a/ValidationLibrary/ValidationLibrary.csproj
+++ b/ValidationLibrary/ValidationLibrary.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Octokit" Version="0.48.0" />
   </ItemGroup>


### PR DESCRIPTION
* Library updates
  * RestSharp from 106.11.3 to 106.11.4
  * Microsoft.Azure.WebJobs.Extensions.DurableTask from 2.2.1 to 2.2.2 
  * coverlet.collector from 1.2.1 to 1.3.0
  * Octokit from 0.47.0 to 0.48.0
  * Microsoft.Extensions.* to 3.1.5
  * nsubstitute from 4.2.1 to 4.2.2
  * NUnit3TestAdapter from 3.16.1 to 3.17.0
  * Microsoft.NET.Sdk.Functions from 3.0.7 to 3.0.9