### PR TITLE
Improve console application config validation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ podTemplate(label: pod.label,
         container('dotnet') {
             stage('Build') {
                 sh """
-                    # Build the whole  system, but only publish Azure Functions project
+                    # Build the whole system, but only publish Azure Functions project
                     dotnet build
                     cd $functionsProject
                     dotnet publish -c Release -o $publishFolder --version-suffix ${env.BUILD_NUMBER}

--- a/Runner/Program.cs
+++ b/Runner/Program.cs
@@ -199,12 +199,12 @@ namespace Runner
 
         private static void ValidateConfig(GitHubConfiguration gitHubConfiguration)
         {
-            if (gitHubConfiguration.Organization == null)
+            if (string.IsNullOrWhiteSpace(gitHubConfiguration.Organization))
             {
                 throw new ArgumentNullException(nameof(gitHubConfiguration.Organization), "Organization was missing.");
             }
 
-            if (gitHubConfiguration.Token == null)
+            if (string.IsNullOrWhiteSpace(gitHubConfiguration.Token))
             {
                 throw new ArgumentNullException(nameof(gitHubConfiguration.Token), "Token was missing.");
             }


### PR DESCRIPTION
Config validation in console runner didn't throw clear exception when organization or token was missing.

Now it does!