### PR TITLE
Use default branch instead of hard coded master branch.

### DIFF
--- a/ValidationLibrary.Rules.Tests/BaseRuleTests.cs
+++ b/ValidationLibrary.Rules.Tests/BaseRuleTests.cs
@@ -16,7 +16,7 @@ namespace ValidationLibrary.Tests.Rules
         protected IRepositoriesClient MockRepositoryClient { get; set; }
         protected IRepositoryContentsClient MockRepositoryContentClient { get; set; }
 
-        protected const string MainBranch = "master";
+        protected const string MainBranch = "main";
 
         [SetUp]
         public async Task Setup()

--- a/ValidationLibrary.Rules.Tests/HasCodeownersRuleTests.cs
+++ b/ValidationLibrary.Rules.Tests/HasCodeownersRuleTests.cs
@@ -105,7 +105,7 @@ namespace ValidationLibrary.Tests.Rules
 
         private Repository CreateRepository(string name)
         {
-            return new Repository(null, null, null, null, null, null, null, 0, null, Owner, name, null, false, null, null, null, false, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, false, false, false, false, 0, 0, null, null, null, false, 0);
+            return new Repository(null, null, null, null, null, null, null, 0, null, Owner, name, null, false, null, null, null, false, false, 0, 0, MainBranch, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, false, false, false, false, 0, 0, null, null, null, false, 0);
         }
     }
 }

--- a/ValidationLibrary.Rules.Tests/HasLicenseRuleTests.cs
+++ b/ValidationLibrary.Rules.Tests/HasLicenseRuleTests.cs
@@ -46,7 +46,7 @@ namespace ValidationLibrary.Tests.Rules
 
         private Repository CreateRepository(string name, bool isPrivate, LicenseMetadata license)
         {
-            return new Repository(null, null, null, null, null, null, null, 0, null, null, name, null, false, null, null, null, isPrivate, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, license, false, false, false, false, 0, 0, null, null, null, false, 0);
+            return new Repository(null, null, null, null, null, null, null, 0, null, null, name, null, false, null, null, null, isPrivate, false, 0, 0, MainBranch, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, license, false, false, false, false, 0, 0, null, null, null, false, 0);
         }
     }
 }

--- a/ValidationLibrary.Rules.Tests/HasNewestPtcsJenkinsLibRuleTests.cs
+++ b/ValidationLibrary.Rules.Tests/HasNewestPtcsJenkinsLibRuleTests.cs
@@ -115,7 +115,7 @@ namespace ValidationLibrary.Tests.Rules
 
         private Repository CreateRepository(string name)
         {
-            return new Repository(null, null, null, null, null, null, null, 0, null, Owner, name, null, false, null, null, null, false, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, false, false, false, false, 0, 0, null, null, null, false, 0);
+            return new Repository(null, null, null, null, null, null, null, 0, null, Owner, name, null, false, null, null, null, false, false, 0, 0, MainBranch, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, false, false, false, false, 0, 0, null, null, null, false, 0);
         }
     }
 }

--- a/ValidationLibrary.Rules.Tests/HasNotManyStaleBranchesRuleTests.cs
+++ b/ValidationLibrary.Rules.Tests/HasNotManyStaleBranchesRuleTests.cs
@@ -47,7 +47,7 @@ namespace ValidationLibrary.Tests.Rules
                 null, null, null, null, null, null,
                 null, 0, null, owner, name, $"{owner}/{name}",
                 false, null, null, null, false, false, 0,
-                0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow,
+                0, MainBranch, 0, null, DateTime.UtcNow, DateTime.UtcNow,
                 null, null, null, null, false, false,
                 false, false, 0, 0, null, null,
                 null, false, 0);

--- a/ValidationLibrary.Rules.Tests/HasReadmeRuleTests.cs
+++ b/ValidationLibrary.Rules.Tests/HasReadmeRuleTests.cs
@@ -77,7 +77,7 @@ namespace ValidationLibrary.Tests.Rules
 
         private Repository CreateRepository(string name)
         {
-            return new Repository(null, null, null, null, null, null, null, 0, null, Owner, name, null, false, null, null, null, false, false, 0, 0, null, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, false, false, false, false, 0, 0, null, null, null, false, 0);
+            return new Repository(null, null, null, null, null, null, null, 0, null, Owner, name, null, false, null, null, null, false, false, 0, 0, MainBranch, 0, null, DateTime.UtcNow, DateTime.UtcNow, null, null, null, null, false, false, false, false, 0, 0, null, null, null, false, 0);
         }
     }
 }

--- a/ValidationLibrary.Rules/FixableRuleBase.cs
+++ b/ValidationLibrary.Rules/FixableRuleBase.cs
@@ -16,7 +16,6 @@ namespace ValidationLibrary.Rules
     {
         public string RuleName { get; }
         protected abstract string PullRequestBody { get; }
-        protected const string MainBranch = "master";
         private readonly ILogger<FixableRuleBase<T>> _logger;
         private readonly GitUtils _gitUtils;
         private readonly string _pullRequestTitle;
@@ -90,8 +89,8 @@ namespace ValidationLibrary.Rules
 
         private async Task CreateNewPullRequest(IGitHubClient client, Repository repository, Reference latest)
         {
-            var master = await client.Git.Reference.Get(repository.Owner.Login, repository.Name, $"heads/{MainBranch}").ConfigureAwait(false);
-            var pullRequest = new NewPullRequest(_pullRequestTitle, latest.Ref, master.Ref)
+            var mainBranch = await client.Git.Reference.Get(repository.Owner.Login, repository.Name, $"heads/{repository.DefaultBranch}").ConfigureAwait(false);
+            var pullRequest = new NewPullRequest(_pullRequestTitle, latest.Ref, mainBranch.Ref)
             {
                 Body = PullRequestBody
             };

--- a/ValidationLibrary.Rules/HasCodeownersRule.cs
+++ b/ValidationLibrary.Rules/HasCodeownersRule.cs
@@ -23,8 +23,6 @@ namespace ValidationLibrary.Rules
     {
         public string RuleName => "Missing CODEOWNERS";
 
-        private const string MainBranch = "master";
-
         private readonly ILogger<HasCodeownersRule> _logger;
 
         public HasCodeownersRule(ILogger<HasCodeownersRule> logger)
@@ -67,8 +65,7 @@ namespace ValidationLibrary.Rules
             return new Dictionary<string, string>
             {
                 { "ClassName", nameof(HasCodeownersRule) },
-                { "RuleName", RuleName },
-                { "MainBranch", MainBranch }
+                { "RuleName", RuleName }
             };
         }
 
@@ -79,7 +76,7 @@ namespace ValidationLibrary.Rules
 
         private async Task<RepositoryContent> GetCodeownersContent(IGitHubClient client, Repository repository)
         {
-            var contents = await GetContents(client, repository, MainBranch).ConfigureAwait(false);
+            var contents = await GetContents(client, repository, repository.DefaultBranch).ConfigureAwait(false);
             var codeownersFile = contents.FirstOrDefault(content => content.Name.Equals("CODEOWNERS", StringComparison.InvariantCultureIgnoreCase));
             var path = "CODEOWNERS";
 
@@ -88,7 +85,7 @@ namespace ValidationLibrary.Rules
                 var directory = contents.FirstOrDefault(content => content.Name.Equals(".github", StringComparison.InvariantCultureIgnoreCase));
                 if (directory != null)
                 {
-                    var directoryContents = await client.Repository.Content.GetAllContentsByRef(repository.Owner.Login, repository.Name, directory.Name, MainBranch).ConfigureAwait(false);
+                    var directoryContents = await client.Repository.Content.GetAllContentsByRef(repository.Owner.Login, repository.Name, directory.Name, repository.DefaultBranch).ConfigureAwait(false);
                     codeownersFile = directoryContents.FirstOrDefault(content => content.Name.Equals("CODEOWNERS", StringComparison.InvariantCultureIgnoreCase));
                     path = ".github/CODEOWNERS";
                 }
@@ -99,7 +96,7 @@ namespace ValidationLibrary.Rules
                 var directory = contents.FirstOrDefault(content => content.Name.Equals("docs", StringComparison.InvariantCultureIgnoreCase));
                 if (directory != null)
                 {
-                    var directoryContents = await client.Repository.Content.GetAllContentsByRef(repository.Owner.Login, repository.Name, directory.Name, MainBranch).ConfigureAwait(false);
+                    var directoryContents = await client.Repository.Content.GetAllContentsByRef(repository.Owner.Login, repository.Name, directory.Name, repository.DefaultBranch).ConfigureAwait(false);
                     codeownersFile = directoryContents.FirstOrDefault(content => content.Name.Equals("CODEOWNERS", StringComparison.InvariantCultureIgnoreCase));
                     path = "docs/CODEOWNERS";
                 }
@@ -111,7 +108,7 @@ namespace ValidationLibrary.Rules
                 _logger.LogDebug("Rule {ruleClass} / {ruleName}, No CODEOWNERS found.", nameof(HasCodeownersRule), RuleName);
                 return null;
             }
-            var matchingFile = await client.Repository.Content.GetAllContentsByRef(repository.Owner.Login, repository.Name, path, MainBranch).ConfigureAwait(false);
+            var matchingFile = await client.Repository.Content.GetAllContentsByRef(repository.Owner.Login, repository.Name, path, repository.DefaultBranch).ConfigureAwait(false);
             return matchingFile[0];
         }
 

--- a/ValidationLibrary.Rules/HasNewestPtcsJenkinsLibRule.cs
+++ b/ValidationLibrary.Rules/HasNewestPtcsJenkinsLibRule.cs
@@ -64,7 +64,7 @@ namespace ValidationLibrary.Rules
 
             _logger.LogTrace("Rule {ruleClass} / {ruleName}, Validating repository {repositoryName}", nameof(HasNewestPtcsJenkinsLibRule), RuleName, repository.FullName);
 
-            var isValid = IsValid(await GetJenkinsFileContent(client, repository, MainBranch).ConfigureAwait(false));
+            var isValid = IsValid(await GetJenkinsFileContent(client, repository, repository.DefaultBranch).ConfigureAwait(false));
 
             return new ValidationResult(RuleName, $"Update {LibraryName} to newest version. Newest version can be found in https://github.com/by-pinja/{LibraryName}/releases",
                 isValid, Fix);
@@ -76,8 +76,7 @@ namespace ValidationLibrary.Rules
             {
                 { "ClassName", nameof(HasNewestPtcsJenkinsLibRule) },
                 { "PullRequestTitle", RuleName },
-                { "LatestJenkinsLibraryVersion", _expectedVersion },
-                { "MainBranch", MainBranch }
+                { "LatestJenkinsLibraryVersion", _expectedVersion }
             };
         }
 

--- a/ValidationLibrary.Rules/HasReadmeRule.cs
+++ b/ValidationLibrary.Rules/HasReadmeRule.cs
@@ -59,7 +59,7 @@ namespace ValidationLibrary.Rules
 
             _logger.LogTrace("Rule {ruleClass} / {ruleName}, Validating repository {repositoryName}",
                 nameof(HasReadmeRule), RuleName, gitHubRepository.FullName);
-            var hasReadmeWithContent = await HasReadmeWithContent(client, gitHubRepository, MainBranch).ConfigureAwait(false);
+            var hasReadmeWithContent = await HasReadmeWithContent(client, gitHubRepository, gitHubRepository.DefaultBranch).ConfigureAwait(false);
 
             _logger.LogDebug("Rule {ruleClass} / {ruleName}, Validating repository {repositoryName}. Readme has content: {readmeHasContent}",
                 nameof(HasReadmeRule), RuleName, gitHubRepository.FullName, hasReadmeWithContent);
@@ -72,8 +72,7 @@ namespace ValidationLibrary.Rules
             {
                 { "ClassName", nameof(HasReadmeRule) },
                 { "PullRequestTitle", _branchName },
-                { "ReadMeTemplateFileLocation", _templateFileUrl.OriginalString },
-                { "MainBranch", MainBranch }
+                { "ReadMeTemplateFileLocation", _templateFileUrl.OriginalString }
             };
         }
 

--- a/ValidationLibrary/RepositoryValidator.cs
+++ b/ValidationLibrary/RepositoryValidator.cs
@@ -43,7 +43,7 @@ namespace ValidationLibrary
                 throw new ArgumentNullException(nameof(gitHubRepository));
             }
 
-            _logger.LogTrace("Validating repository {repositoryName}", gitHubRepository.FullName);
+            _logger.LogTrace("Validating repository {repositoryName}, default branch: {branch}", gitHubRepository.FullName, gitHubRepository.DefaultBranch);
             var config = await GetConfig(gitHubRepository).ConfigureAwait(false);
 
             var filteredRules = overrideRuleIgnore ? Rules : Rules.Where(rule =>


### PR DESCRIPTION
Because GitHub has changed its' default branch to `main`, issue #369 escalated from `enchantment` to `bug` it would be a good time to use default branch configured in repository instead of hard coded `master`.

Closes #369