### PR TITLE
Production release

### DIFF
--- a/.github/workflows/wiki-publish.yml
+++ b/.github/workflows/wiki-publish.yml
@@ -11,7 +11,7 @@ jobs:
     name: Publish wiki
     # This job runs on Linux
     runs-on: ubuntu-latest
-    container: ptcos/multi-netcore-sdk:0.0.2
+    container: mcr.microsoft.com/dotnet/sdk:6.0-alpine
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,12 +5,12 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": ".NET Core Launch (console)",
+      "name": ".NET 6.0 Launch (console)",
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/Runner/bin/Debug/netcoreapp3.1/Runner.dll",
+      "program": "${workspaceFolder}/Runner/bin/Debug/net6.0/Runner.dll",
       "args": [
         "scan-selected",
         "-r",

--- a/AcceptanceTests/AcceptanceTests.csproj
+++ b/AcceptanceTests/AcceptanceTests.csproj
@@ -11,11 +11,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.21" />
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="RestSharp" Version="106.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="RestSharp" Version="106.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AcceptanceTests/AcceptanceTests.csproj
+++ b/AcceptanceTests/AcceptanceTests.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.21" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="RestSharp" Version="106.13.0" />
+    <PackageReference Include="RestSharp" Version="107.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AcceptanceTests/BasicTests.cs
+++ b/AcceptanceTests/BasicTests.cs
@@ -64,10 +64,10 @@ namespace AcceptanceTests
             Assert.AreEqual(HttpStatusCode.Accepted, result.StatusCode);
         }
 
-        private async Task<IRestResponse> SendRequest(object obj)
+        private async Task<RestResponse> SendRequest(object obj)
         {
             var client = new RestClient();
-            var request = new RestRequest(_url, Method.POST);
+            var request = new RestRequest(_url, Method.Post);
             request.AddQueryParameter("code", _code);
             request.AddJsonBody(obj);
 

--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -62,13 +62,15 @@
     },
     {
       "type": "Microsoft.Web/serverfarms",
-      "apiVersion": "2015-04-01",
+      "apiVersion": "2020-12-01",
       "name": "[variables('hostingPlanName')]",
       "location": "[parameters('location')]",
+      "sku": {
+        "name": "Y1",
+        "capacity": 1
+      },
       "properties": {
-        "name": "[variables('hostingPlanName')]",
-        "computeMode": "Dynamic",
-        "sku": "Dynamic"
+        "name": "[variables('hostingPlanName')]"
       },
       "tags": {
         "displayName": "Server for function app",
@@ -110,26 +112,26 @@
             },
             {
               "name": "FUNCTIONS_EXTENSION_VERSION",
-              "value": "~3"
+              "value": "~4"
             },
             {
-              "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "6.5.0"
+              "name": "FUNCTIONS_WORKER_RUNTIME",
+              "value": "dotnet"
             },
             {
               "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
               "value": "[reference(resourceId('microsoft.insights/components/', variables('applicationInsightsName')), '2015-05-01').InstrumentationKey]"
             },
             {
-              "name": "GitHub:Token",
+              "name": "GitHub__Token",
               "value": "[parameters('gitHubToken')]"
             },
             {
-              "name": "GitHub:Organization",
+              "name": "GitHub__Organization",
               "value": "[parameters('gitHubOrganization')]"
             },
             {
-              "name": "Rules:HasCodeownersRule",
+              "name": "Rules__HasCodeownersRule",
               "value": "disable"
             }
           ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 library 'jenkins-ptcs-library@3.1.0'
 
-def isDependabot(branchName) { return branchName.toString().startsWith("dependabot/nuget") }
+def isDependabot(branchName) { return branchName.toString().startsWith("feature/buildtest") }
 def isMaster(branchName) { return branchName == "master" }
 def isTest(branchName) { return branchName == "test" }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ def isTest(branchName) { return branchName == "test" }
 
 podTemplate(label: pod.label,
   containers: pod.templates + [
-    containerTemplate(name: 'dotnet', image: 'ptcos/multi-netcore-sdk:0.0.2', ttyEnabled: true, command: '/bin/sh -c', args: 'cat'),
+    containerTemplate(name: 'dotnet', image: 'mcr.microsoft.com/dotnet/sdk:6.0-alpine', ttyEnabled: true, command: '/bin/sh -c', args: 'cat'),
     containerTemplate(name: 'powershell', image: 'azuresdk/azure-powershell-core:master', ttyEnabled: true, command: '/bin/sh -c', args: 'cat')
   ]
 ) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ def isTest(branchName) { return branchName == "test" }
 podTemplate(label: pod.label,
   containers: pod.templates + [
     containerTemplate(name: 'dotnet', image: 'mcr.microsoft.com/dotnet/sdk:6.0-alpine', ttyEnabled: true, command: '/bin/sh -c', args: 'cat'),
-    containerTemplate(name: 'powershell', image: 'azuresdk/azure-powershell-core:master', ttyEnabled: true, command: '/bin/sh -c', args: 'cat')
+    containerTemplate(name: 'powershell', image: 'mcr.microsoft.com/azure-powershell:alpine-3.14', ttyEnabled: true, command: '/bin/sh -c', args: 'cat')
   ]
 ) {
 

--- a/Runner.Tests/Runner.Tests.csproj
+++ b/Runner.Tests/Runner.Tests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Runner.Tests/Runner.Tests.csproj
+++ b/Runner.Tests/Runner.Tests.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 

--- a/Runner/Runner.csproj
+++ b/Runner/Runner.csproj
@@ -2,17 +2,17 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.21" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.21" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.21" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.21" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.21" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.21" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Runner/Runner.csproj
+++ b/Runner/Runner.csproj
@@ -7,12 +7,12 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.21" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.21" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.21" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.21" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.21" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ValidationLibrary.AzureFunctions.Tests/ValidationLibrary.AzureFunctions.Tests.csproj
+++ b/ValidationLibrary.AzureFunctions.Tests/ValidationLibrary.AzureFunctions.Tests.csproj
@@ -13,8 +13,8 @@
     </PackageReference>
     <PackageReference Include="nsubstitute" Version="4.2.2" />
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ValidationLibrary.AzureFunctions.Tests/ValidationLibrary.AzureFunctions.Tests.csproj
+++ b/ValidationLibrary.AzureFunctions.Tests/ValidationLibrary.AzureFunctions.Tests.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="nsubstitute" Version="4.2.2" />
+    <PackageReference Include="nsubstitute" Version="4.3.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 

--- a/ValidationLibrary.AzureFunctions/.vscode/settings.json
+++ b/ValidationLibrary.AzureFunctions/.vscode/settings.json
@@ -2,7 +2,7 @@
   "azureFunctions.projectRuntime": "~3",
   "azureFunctions.projectLanguage": "C#",
   "azureFunctions.templateFilter": "Verified",
-  "azureFunctions.deploySubpath": "bin/Release/netcoreapp3.0/publish",
+  "azureFunctions.deploySubpath": "bin/Release/net6.0/publish",
   "azureFunctions.preDeployTask": "publish",
   "debug.internalConsoleOptions": "neverOpen"
 }

--- a/ValidationLibrary.AzureFunctions/.vscode/tasks.json
+++ b/ValidationLibrary.AzureFunctions/.vscode/tasks.json
@@ -48,7 +48,7 @@
       "type": "shell",
       "dependsOn": "build",
       "options": {
-        "cwd": "${workspaceFolder}/bin/Debug/netcoreapp3.0"
+        "cwd": "${workspaceFolder}/bin/Debug/net6.0"
       },
       "command": "func host start",
       "isBackground": true,

--- a/ValidationLibrary.AzureFunctions/ValidationLibrary.AzureFunctions.csproj
+++ b/ValidationLibrary.AzureFunctions/ValidationLibrary.AzureFunctions.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.18.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.5.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.6.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/ValidationLibrary.AzureFunctions/ValidationLibrary.AzureFunctions.csproj
+++ b/ValidationLibrary.AzureFunctions/ValidationLibrary.AzureFunctions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/ValidationLibrary.AzureFunctions/ValidationLibrary.AzureFunctions.csproj
+++ b/ValidationLibrary.AzureFunctions/ValidationLibrary.AzureFunctions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
 
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.18.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.6.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/ValidationLibrary.GitHub.Tests/ValidationLibrary.GitHub.Tests.csproj
+++ b/ValidationLibrary.GitHub.Tests/ValidationLibrary.GitHub.Tests.csproj
@@ -13,8 +13,8 @@
     </PackageReference>
     <PackageReference Include="nsubstitute" Version="4.2.2" />
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ValidationLibrary.GitHub.Tests/ValidationLibrary.GitHub.Tests.csproj
+++ b/ValidationLibrary.GitHub.Tests/ValidationLibrary.GitHub.Tests.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="nsubstitute" Version="4.2.2" />
+    <PackageReference Include="nsubstitute" Version="4.3.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 

--- a/ValidationLibrary.GitHub/ValidationLibrary.GitHub.csproj
+++ b/ValidationLibrary.GitHub/ValidationLibrary.GitHub.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/ValidationLibrary.MarkdownGenerator.Tests/ValidationLibrary.MarkdownGenerator.Tests.csproj
+++ b/ValidationLibrary.MarkdownGenerator.Tests/ValidationLibrary.MarkdownGenerator.Tests.csproj
@@ -12,8 +12,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ValidationLibrary.MarkdownGenerator.Tests/ValidationLibrary.MarkdownGenerator.Tests.csproj
+++ b/ValidationLibrary.MarkdownGenerator.Tests/ValidationLibrary.MarkdownGenerator.Tests.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 

--- a/ValidationLibrary.MarkdownGenerator/ValidationLibrary.MarkdownGenerator.csproj
+++ b/ValidationLibrary.MarkdownGenerator/ValidationLibrary.MarkdownGenerator.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/ValidationLibrary.Rules.Tests/ValidationLibrary.Rules.Tests.csproj
+++ b/ValidationLibrary.Rules.Tests/ValidationLibrary.Rules.Tests.csproj
@@ -13,8 +13,8 @@
     </PackageReference>
     <PackageReference Include="nsubstitute" Version="4.2.2" />
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ValidationLibrary.Rules.Tests/ValidationLibrary.Rules.Tests.csproj
+++ b/ValidationLibrary.Rules.Tests/ValidationLibrary.Rules.Tests.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="nsubstitute" Version="4.2.2" />
+    <PackageReference Include="nsubstitute" Version="4.3.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 

--- a/ValidationLibrary.Rules/ExtensionMethods.cs
+++ b/ValidationLibrary.Rules/ExtensionMethods.cs
@@ -13,7 +13,7 @@ namespace ValidationLibrary.Rules
             var allValidationRules = typeof(ExtensionMethods).Assembly.GetExportedTypes().Where(t => t.GetInterface(nameof(IValidationRule)) != null && !t.IsAbstract);
 
             // Select those rules defined by the configuration and the environment variables which should be disabled.
-            var selectedValidationRules = allValidationRules.Where(r => !string.Equals(config.GetValue<string>($"Rules:{r.Name}"), "disable", StringComparison.InvariantCultureIgnoreCase));
+            var selectedValidationRules = allValidationRules.Where(r => !string.Equals(config[$"Rules:{r.Name}"], "disable", StringComparison.InvariantCultureIgnoreCase));
 
             // Add each rule as available for the dependency injection.
             foreach (var rule in selectedValidationRules)

--- a/ValidationLibrary.Rules/HasNewestPtcsJenkinsLibRule.cs
+++ b/ValidationLibrary.Rules/HasNewestPtcsJenkinsLibRule.cs
@@ -93,14 +93,14 @@ namespace ValidationLibrary.Rules
             var match = matches.OfType<Match>().FirstOrDefault();
             if (match == null)
             {
-                _logger.LogTrace("Rule {ruleClass} / {ruleName}, no jenkins-ptcs-library matches found. Skipping.", nameof(HasNewestPtcsJenkinsLibRule), RuleName, JenkinsFileName);
+                _logger.LogTrace("Rule {ruleClass} / {ruleName}, no jenkins-ptcs-library matches found. Skipping.", nameof(HasNewestPtcsJenkinsLibRule), RuleName);
                 return true;
             }
 
             var group = match.Groups.OfType<Group>().LastOrDefault();
             if (group == null)
             {
-                _logger.LogTrace("Rule {ruleClass} / {ruleName}, no jenkins-ptcs-library groups found. Skipping.", nameof(HasNewestPtcsJenkinsLibRule), RuleName, JenkinsFileName);
+                _logger.LogTrace("Rule {ruleClass} / {ruleName}, no jenkins-ptcs-library groups found. Skipping.", nameof(HasNewestPtcsJenkinsLibRule), RuleName);
                 return true;
             }
 

--- a/ValidationLibrary.Rules/ValidationLibrary.Rules.csproj
+++ b/ValidationLibrary.Rules/ValidationLibrary.Rules.csproj
@@ -1,17 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.21" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Octokit" Version="0.50.0" />
   </ItemGroup>
 

--- a/ValidationLibrary.Rules/ValidationLibrary.Rules.csproj
+++ b/ValidationLibrary.Rules/ValidationLibrary.Rules.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.21" />
     <PackageReference Include="Octokit" Version="0.50.0" />
   </ItemGroup>
 

--- a/ValidationLibrary.Slack/ValidationLibrary.Slack.csproj
+++ b/ValidationLibrary.Slack/ValidationLibrary.Slack.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ValidationLibrary.Tests/ValidationLibrary.Tests.csproj
+++ b/ValidationLibrary.Tests/ValidationLibrary.Tests.csproj
@@ -13,8 +13,8 @@
     </PackageReference>
     <PackageReference Include="nsubstitute" Version="4.2.2" />
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ValidationLibrary.Tests/ValidationLibrary.Tests.csproj
+++ b/ValidationLibrary.Tests/ValidationLibrary.Tests.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="nsubstitute" Version="4.2.2" />
+    <PackageReference Include="nsubstitute" Version="4.3.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 

--- a/ValidationLibrary/ValidationLibrary.csproj
+++ b/ValidationLibrary/ValidationLibrary.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.21" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Octokit" Version="0.50.0" />
   </ItemGroup>

--- a/ValidationLibrary/ValidationLibrary.csproj
+++ b/ValidationLibrary/ValidationLibrary.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.21" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Octokit" Version="0.50.0" />
   </ItemGroup>


### PR DESCRIPTION
Major

* Migrating to net 6.0!
* Migrate to official Azure Powershell container [mcr.microsoft.com/azure-powershell](https://hub.docker.com/_/microsoft-azure-powershell)
* Use Azure Functions 4.0

All:

* Move from netcoreapp3.1 to net6.0.
  * net 5.0 can't be used, because Azure Durable Functions requires In-process (Isolated process). net7.0 has durable functions with isolated process support on roadmap (https://techcommunity.microsoft.com/t5/apps-on-azure-blog/net-on-azure-functions-roadmap/ba-p/2197916)
* Also migrate from netstandard2.0 to netstandard2.1
* Update following
  * Microsoft.Extensions.* from 3.1.21 to 6.0.0 (these were held back by net5.0 not being supported)
  * Microsoft.NET.Sdk.Functions from 3.0.13 to 4.0.1 ([net 6.0](https://techcommunity.microsoft.com/t5/apps-on-azure-blog/azure-functions-4-0-and-net-6-support-are-now-generally/ba-p/2933245))
  * Microsoft.ApplicationInsights from 2.18.0 to 2.20.0
  * Microsoft.CodeAnalysis.NetAnalyzers from 5.0.3 to 6.0.0
  * Microsoft.Azure.WebJobs.Extensions.DurableTask from 2.6.0 to 2.6.1
  * coverlet.collector 3.1.0 to 3.1.2
  * NUnit3TestAdapter to 4.1.0 to 4.2.1
  * nsubstitute 4.2.2 to 4.3.0
  * RestSharp 106.13.0 to 107.3.0
* Use mcr.microsoft.com/dotnet/sdk:6.0-alpine instead of ptcos/multi-netcore-sdk:0.0.2, because features provided by multi-netcore-sdk are no longer necessary.